### PR TITLE
Fixed missing double-quotes needed for paths with spaces.

### DIFF
--- a/coding-style.sh
+++ b/coding-style.sh
@@ -24,7 +24,7 @@ then
 
     ### generate reports
     sudo docker run --rm -i -v "$DELIVERY_DIR":"/mnt/delivery" -v "$REPORTS_DIR":"/mnt/reports" ghcr.io/epitech/coding-style-checker:latest "/mnt/delivery" "/mnt/reports"
-    [[ -f $EXPORT_FILE ]] && echo "$(wc -l < $EXPORT_FILE) coding style error(s) reported in $EXPORT_FILE, $(grep -c ": MAJOR:" $EXPORT_FILE) major, $(grep -c ": MINOR:" $EXPORT_FILE) minor, $(grep -c ": INFO:" $EXPORT_FILE) info"
+    [[ -f "$EXPORT_FILE" ]] && echo "$(wc -l < "$EXPORT_FILE") coding style error(s) reported in "$EXPORT_FILE", $(grep -c ": MAJOR:" "$EXPORT_FILE") major, $(grep -c ": MINOR:" "$EXPORT_FILE") minor, $(grep -c ": INFO:" "$EXPORT_FILE") info"
 else
     cat_readme
 fi

--- a/coding-style.sh
+++ b/coding-style.sh
@@ -17,7 +17,7 @@ then
     REPORTS_DIR=$(readlink -f "$2")
     EXPORT_FILE="$REPORTS_DIR"/coding-style-reports.log
     ### delete existing report file
-    rm -f $EXPORT_FILE
+    rm -f "$EXPORT_FILE"
 
     ### Pull new version of docker image and clean olds
     sudo docker pull ghcr.io/epitech/coding-style-checker:latest && sudo docker image prune -f


### PR DESCRIPTION
## Error's location
coding-style.sh

## Platform concerned
[x] Linux
[ ] Windows

## Error's description
When supplying a directory whose path contain spaces to the script as the input or output directory, the script errors and freezes on:
`grep: /path/to/dir_with_spaces/<first word>: No such file or directory`

## Error reproduction
`cd`
`mkdir 'Test directory'`
`coding-style.sh '~/Test directory' ~`
`...`
`grep: /home/$USER/Test: No such file or directory` (granted you have no ~/Test directory, but either way it targets the wrong dir)