### PR TITLE
fix?: automatically add user to docker group when needed

### DIFF
--- a/coding-style.sh
+++ b/coding-style.sh
@@ -17,20 +17,30 @@ function cat_readme() {
 
 if [ $# == 1 ] && [ $1 == "--help" ]; then
     cat_readme
-elif [ $# = 2 ];
-then
+elif [ $# = 2 ]; then
     DELIVERY_DIR=$(my_readlink "$1")
     REPORTS_DIR=$(my_readlink "$2")
     EXPORT_FILE="$REPORTS_DIR"/coding-style-reports.log
     ### delete existing report file
     rm -f "$EXPORT_FILE"
 
-    ### Pull new version of docker image and clean olds
-    sudo docker pull ghcr.io/epitech/coding-style-checker:latest && sudo docker image prune -f
+    if [[ $(/usr/bin/groups) != *"docker"* ]]; then
+        if [[ $(/usr/bin/cat /etc/group | grep docker) != *"$(/usr/bin/whoami)"* ]]; then
+            echo -e "\nAdding your user to the 'docker' group.\n"
+            sudo usermod -a -G docker "$(/usr/bin/whoami)"
+            echo -e "\nPlease logout and back in to apply the modifications.\n"
+        else
+            echo -e "\nYou haven't logged out and back in yet, \`sudo\` might ask for your password.\n"
+        fi
+        sudo su -c "$0 $(echo $@)" "$(/usr/bin/whoami)"
+    else
+        ### Pull new version of docker image and clean olds
+        docker pull ghcr.io/epitech/coding-style-checker:latest && docker image prune -f
 
-    ### generate reports
-    sudo docker run --rm -i -v "$DELIVERY_DIR":"/mnt/delivery" -v "$REPORTS_DIR":"/mnt/reports" ghcr.io/epitech/coding-style-checker:latest "/mnt/delivery" "/mnt/reports"
-    [[ -f "$EXPORT_FILE" ]] && echo "$(wc -l < "$EXPORT_FILE") coding style error(s) reported in "$EXPORT_FILE", $(grep -c ": MAJOR:" "$EXPORT_FILE") major, $(grep -c ": MINOR:" "$EXPORT_FILE") minor, $(grep -c ": INFO:" "$EXPORT_FILE") info"
+        ### generate reports
+        docker run --rm -i -v "$DELIVERY_DIR":"/mnt/delivery" -v "$REPORTS_DIR":"/mnt/reports" ghcr.io/epitech/coding-style-checker:latest "/mnt/delivery" "/mnt/reports"
+        [[ -f "$EXPORT_FILE" ]] && echo "$(wc -l < "$EXPORT_FILE") coding style error(s) reported in "$EXPORT_FILE", $(grep -c ": MAJOR:" "$EXPORT_FILE") major, $(grep -c ": MINOR:" "$EXPORT_FILE") minor, $(grep -c ": INFO:" "$EXPORT_FILE") info"
+    fi
 else
     cat_readme
 fi


### PR DESCRIPTION
Using `sudo` is annoying, it remembers your password for 10 minutes and
afterwards you need to enter it again.

This PR checks if the user is in the `docker` group, add it if needed and
remove the calls to `sudo` before the docker commands.

I know using the `docker` group is a bad practice
([here](https://fosterelli.co/privilege-escalation-via-docker.html)) so if
this isn't ok, I can refactor it to just not use `sudo` only if the user added
themself to the group `docker`.
