### PR TITLE
Add Nix supports through Flakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,28 @@
 ### Linux
 
 Requirement :
-- [Docker](https://docs.docker.com/engine/install/) installed 
+
+- [Docker](https://docs.docker.com/engine/install/) installed
 - [Curl](https://curl.se/download.html) installed
 
 Use `coding-style.sh`
 
+If using Nix, you can run `nix run github:epitech/coding-style-checker` to run a script printing you the list of infractions.
+
 ### Windows
 
-Requirements : 
+Requirements :
+
 - [Docker](https://docs.docker.com/engine/install/) installed
 - [Powershell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows) installed
 
 Use `coding-style.ps1`
+
+### MacOS
+
+Requirements :
+
+- [Nix](https://github.com/DeterminateSystems/nix-installer) installed
+
+Use `nix run github:epitech/coding-style-checker` to run a script printing you the list of infractions.
+(Supports both Intel and Apple Silicon)

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1678293141,
+        "narHash": "sha256-lLlQHaR0y+q6nd6kfpydPTGHhl1rS9nU9OQmztzKOYs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c90c4025bb6e0c4eaf438128a3b2640314b1c58d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "ruleset": "ruleset",
+        "vera": "vera"
+      }
+    },
+    "ruleset": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1669714262,
+        "narHash": "sha256-fuUN4dYEI2c51veBvyM+vzxhA4AlmbrTJ+NJOzYq3Fo=",
+        "ref": "refs/heads/main",
+        "rev": "a97bb704dd0d341128e05aaa016930e787d6bc31",
+        "revCount": 9,
+        "type": "git",
+        "url": "ssh://git@github.com/Epitech/banana-coding-style-checker.git"
+      },
+      "original": {
+        "type": "git",
+        "url": "ssh://git@github.com/Epitech/banana-coding-style-checker.git"
+      }
+    },
+    "vera": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1661342940,
+        "narHash": "sha256-1nAKhUltQS1301JNrr0PQQrrf2W9Hj5gk1nbUhN4cXw=",
+        "owner": "Epitech",
+        "repo": "banana-vera",
+        "rev": "3a7d18d6249cd1790cc63fb9018e0914462ec219",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Epitech",
+        "repo": "banana-vera",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1678293141,
@@ -18,9 +33,10 @@
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "ruleset": "ruleset",
-        "vera": "vera"
+        "vera-fork": "vera-fork"
       }
     },
     "ruleset": {
@@ -39,7 +55,7 @@
         "url": "ssh://git@github.com/Epitech/banana-coding-style-checker.git"
       }
     },
-    "vera": {
+    "vera-fork": {
       "flake": false,
       "locked": {
         "lastModified": 1661342940,

--- a/flake.nix
+++ b/flake.nix
@@ -43,33 +43,30 @@
               fi
 
               echo "Running norm in $project_dir"
-              files=$(find "$project_dir"  \
-                  -type f                  \
-                  -not -path "*/.git/*"    \
-                  -not -path "*/.idea/*"   \
-                  -not -path "*/.vscode/*" \
-                  -not -path "bonus/*"     \
-                  -not -path "tests/*"     \
-                  -not -path "/*build/*"   \
+              count=$(find "$project_dir"     \
+                -type f                       \
+                -not -path "*/.git/*"         \
+                -not -path "*/.idea/*"        \
+                -not -path "*/.vscode/*"      \
+                -not -path "bonus/*"          \
+                -not -path "tests/*"          \
+                -not -path "/*build/*"        \
+                | ${packages.vera}/bin/vera++ \
+                --profile epitech             \
+                --root ${ruleset}/vera        \
+                --error                       \
+                2>&1                          \
+                | sed "s|$project_dir/||"     \
+                | tee /dev/tty | wc -l
               )
-
-              echo "Checking $(echo $files | wc -w) files"
-              # shellcheck disable=SC2046
-              output=$(${packages.vera}/bin/vera++  \
-                  --profile epitech                 \
-                  --root ${ruleset}/vera            \
-                  -d $(echo "$files" | tr '\n' ' ') \
-              )
-
-              if [ -z "$output" ]; then
-                  echo "No issue found."
-              else
-                  escaped_path=$(echo $project_dir | sed 's/\//\\\//g')
-                  echo "$output" | sed "s/$escaped_path\///g"
-                  echo "Found $(echo "$output" | grep -c "$") issues"
-              fi
+              
+              echo "Found $count issues"
               end_time=$(date +%s%3N)
               echo "Ran in $((end_time - start_time))ms"
+              if [ $count -gt 0 ]; then
+                  exit 1
+              fi
+              exit 0
             '');
             default = report;
           };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,85 @@
+{
+  description = "Print EPITECH's coding style compliance report";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    vera.url = "github:Epitech/banana-vera";
+    vera.flake = false;
+    ruleset.url = "git+ssh://git@github.com/Epitech/banana-coding-style-checker.git";
+    ruleset.flake = false;
+  };
+  outputs = { self, nixpkgs, vera, ruleset, ... }@inputs:
+    let
+      pkgs = import nixpkgs { system = "x86_64-linux"; };
+    in
+    {
+      packages.x86_64-linux.vera = pkgs.stdenv.mkDerivation {
+        pname = "vera++";
+        version = "1.3.0";
+
+        src = vera;
+
+        nativeBuildInputs = [ pkgs.cmake ];
+        buildInputs = [
+          pkgs.python3
+          (pkgs.boost.override { enablePython = true; python = pkgs.python3; })
+          pkgs.tcl
+        ];
+
+        cmakeFlags = [
+          "-DVERA_LUA=OFF"
+          "-DVERA_USE_SYSTEM_BOOST=ON"
+          "-DPANDOC=OFF"
+        ];
+      };
+      packages.x86_64-linux.report = pkgs.writeShellScriptBin "cs" ''
+        start_time=$(date +%s%3N)
+
+        if [ -z "$1" ]; then
+            project_dir=$(pwd)
+        else
+            project_dir="$1"
+        fi
+
+        echo "Running norm in $project_dir"
+        files=$(find "$project_dir"  \
+            -type f                  \
+            -not -path "*/.git/*"    \
+            -not -path "*/.idea/*"   \
+            -not -path "*/.vscode/*" \
+            -not -path "bonus/*"     \
+            -not -path "tests/*"     \
+            -not -path "/*build/*"   \
+        )
+
+        echo "Checking $(echo $files | wc -w) files"
+        # shellcheck disable=SC2046
+        output=$(${self.packages.x86_64-linux.vera}/bin/vera++ \
+            --profile epitech                                  \
+            --root ${ruleset}/vera                             \
+            -d $(echo "$files" | tr '\n' ' ')                  \
+        )
+
+        if [ -z "$output" ]; then
+            echo "No issue found."
+        else
+            escaped_path=$(echo $project_dir | sed 's/\//\\\//g')
+            echo "$output" | sed "s/$escaped_path\///g"
+            echo "Found $(echo "$output" | grep -c "$") issues"
+        fi
+        end_time=$(date +%s%3N)
+        echo "Ran in $((end_time - start_time))ms"
+      '';
+      packages.x86_64-linux.default = self.packages.x86_64-linux.report;
+
+      apps.x86_64-linux.vera = {
+        type = "app";
+        program = "${self.packages.x86_64-linux.vera}/bin/vera++";
+      };
+      apps.x86_64-linux.report = {
+        type = "app";
+        program = "${self.packages.x86_64-linux.report}/bin/cs";
+      };
+      apps.x86_64-linux.default = self.apps.x86_64-linux.report;
+    };
+}
+

--- a/flake.nix
+++ b/flake.nix
@@ -2,84 +2,84 @@
   description = "Print EPITECH's coding style compliance report";
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    vera.url = "github:Epitech/banana-vera";
-    vera.flake = false;
+    vera-fork.url = "github:Epitech/banana-vera";
+    vera-fork.flake = false;
     ruleset.url = "git+ssh://git@github.com/Epitech/banana-coding-style-checker.git";
     ruleset.flake = false;
+    flake-utils.url = "github:numtide/flake-utils";
   };
-  outputs = { self, nixpkgs, vera, ruleset, ... }@inputs:
-    let
-      pkgs = import nixpkgs { system = "x86_64-linux"; };
-    in
-    {
-      packages.x86_64-linux.vera = pkgs.stdenv.mkDerivation {
-        pname = "vera++";
-        version = "1.3.0";
+  outputs = { self, nixpkgs, vera-fork, ruleset, flake-utils, ... }@inputs:
+    flake-utils.lib.eachDefaultSystem
+      (system:
+        let pkgs = nixpkgs.legacyPackages.${system}; in
+        rec {
+          packages = flake-utils.lib.flattenTree rec {
+            vera = pkgs.stdenv.mkDerivation {
+              pname = "vera++";
+              version = "1.3.0";
 
-        src = vera;
+              src = vera-fork;
 
-        nativeBuildInputs = [ pkgs.cmake ];
-        buildInputs = [
-          pkgs.python3
-          (pkgs.boost.override { enablePython = true; python = pkgs.python3; })
-          pkgs.tcl
-        ];
+              nativeBuildInputs = [ pkgs.cmake ];
+              buildInputs = [
+                pkgs.python3
+                (pkgs.boost.override { enablePython = true; python = pkgs.python3; })
+                pkgs.tcl
+              ];
 
-        cmakeFlags = [
-          "-DVERA_LUA=OFF"
-          "-DVERA_USE_SYSTEM_BOOST=ON"
-          "-DPANDOC=OFF"
-        ];
-      };
-      packages.x86_64-linux.report = pkgs.writeShellScriptBin "cs" ''
-        start_time=$(date +%s%3N)
+              cmakeFlags = [
+                "-DVERA_LUA=OFF"
+                "-DVERA_USE_SYSTEM_BOOST=ON"
+                "-DPANDOC=OFF"
+              ];
+            };
+            report = (pkgs.writeShellScriptBin "cs" ''
+              start_time=$(date +%s%3N)
 
-        if [ -z "$1" ]; then
-            project_dir=$(pwd)
-        else
-            project_dir="$1"
-        fi
+              if [ -z "$1" ]; then
+                  project_dir=$(pwd)
+              else
+                  project_dir="$1"
+              fi
 
-        echo "Running norm in $project_dir"
-        files=$(find "$project_dir"  \
-            -type f                  \
-            -not -path "*/.git/*"    \
-            -not -path "*/.idea/*"   \
-            -not -path "*/.vscode/*" \
-            -not -path "bonus/*"     \
-            -not -path "tests/*"     \
-            -not -path "/*build/*"   \
-        )
+              echo "Running norm in $project_dir"
+              files=$(find "$project_dir"  \
+                  -type f                  \
+                  -not -path "*/.git/*"    \
+                  -not -path "*/.idea/*"   \
+                  -not -path "*/.vscode/*" \
+                  -not -path "bonus/*"     \
+                  -not -path "tests/*"     \
+                  -not -path "/*build/*"   \
+              )
 
-        echo "Checking $(echo $files | wc -w) files"
-        # shellcheck disable=SC2046
-        output=$(${self.packages.x86_64-linux.vera}/bin/vera++ \
-            --profile epitech                                  \
-            --root ${ruleset}/vera                             \
-            -d $(echo "$files" | tr '\n' ' ')                  \
-        )
+              echo "Checking $(echo $files | wc -w) files"
+              # shellcheck disable=SC2046
+              output=$(${packages.vera}/bin/vera++  \
+                  --profile epitech                 \
+                  --root ${ruleset}/vera            \
+                  -d $(echo "$files" | tr '\n' ' ') \
+              )
 
-        if [ -z "$output" ]; then
-            echo "No issue found."
-        else
-            escaped_path=$(echo $project_dir | sed 's/\//\\\//g')
-            echo "$output" | sed "s/$escaped_path\///g"
-            echo "Found $(echo "$output" | grep -c "$") issues"
-        fi
-        end_time=$(date +%s%3N)
-        echo "Ran in $((end_time - start_time))ms"
-      '';
-      packages.x86_64-linux.default = self.packages.x86_64-linux.report;
+              if [ -z "$output" ]; then
+                  echo "No issue found."
+              else
+                  escaped_path=$(echo $project_dir | sed 's/\//\\\//g')
+                  echo "$output" | sed "s/$escaped_path\///g"
+                  echo "Found $(echo "$output" | grep -c "$") issues"
+              fi
+              end_time=$(date +%s%3N)
+              echo "Ran in $((end_time - start_time))ms"
+            '');
+            default = report;
+          };
 
-      apps.x86_64-linux.vera = {
-        type = "app";
-        program = "${self.packages.x86_64-linux.vera}/bin/vera++";
-      };
-      apps.x86_64-linux.report = {
-        type = "app";
-        program = "${self.packages.x86_64-linux.report}/bin/cs";
-      };
-      apps.x86_64-linux.default = self.apps.x86_64-linux.report;
-    };
+          apps.vera.type = "app";
+          apps.vera.program = "${packages.vera}/bin/vera++";
+
+          apps.report.type = "app";
+          apps.report.program = "${packages.report}/bin/cs";
+          apps.default = apps.report;
+        });
 }
 


### PR DESCRIPTION
Hello

This PR is made to include another way of running the coding style, via [Nix](https://nixos.org/).

It uses EPITECH own fork of [vera++](https://github.com/Epitech/banana-vera) and your [coding style repository](https://github.com/Epitech/banana-coding-style-checker)

(Note: This does not mean that the coding style repository is made public. Nix can't make use of this without an SSH key setup for the user)

It's main use is for MacOS and Linux student not wanting to use Docker, and through GitHub workflows (thanks for example to DeterminateSystem's [Nix Installer](https://github.com/DeterminateSystems/nix-installer))