### PR TITLE
:arrow_up: Update nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1676283394,
-        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "lastModified": 1687171271,
+        "narHash": "sha256-BJlq+ozK2B1sJDQXS3tzJM5a+oVZmi1q0FlBK/Xqv7M=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "rev": "abfb11bd1aec8ced1c9bb9adfe68018230f4fb3c",
         "type": "github"
       },
       "original": {
@@ -17,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1678293141,
-        "narHash": "sha256-lLlQHaR0y+q6nd6kfpydPTGHhl1rS9nU9OQmztzKOYs=",
+        "lastModified": 1686960236,
+        "narHash": "sha256-AYCC9rXNLpUWzD9hm+askOfpliLEC9kwAo7ITJc4HIw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c90c4025bb6e0c4eaf438128a3b2640314b1c58d",
+        "rev": "04af42f3b31dba0ef742d254456dc4c14eedac86",
         "type": "github"
       },
       "original": {
@@ -35,18 +38,17 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "ruleset": "ruleset",
-        "vera-fork": "vera-fork"
+        "ruleset": "ruleset"
       }
     },
     "ruleset": {
       "flake": false,
       "locked": {
-        "lastModified": 1669714262,
-        "narHash": "sha256-fuUN4dYEI2c51veBvyM+vzxhA4AlmbrTJ+NJOzYq3Fo=",
+        "lastModified": 1682512118,
+        "narHash": "sha256-hzJ8Kj0C4dWA5Ndpram5MoZo12Q1IcKnwDc5wOQD+VU=",
         "ref": "refs/heads/main",
-        "rev": "a97bb704dd0d341128e05aaa016930e787d6bc31",
-        "revCount": 9,
+        "rev": "c96976165c4f05fdeaed419018159ac651e82f41",
+        "revCount": 14,
         "type": "git",
         "url": "ssh://git@github.com/Epitech/banana-coding-style-checker.git"
       },
@@ -55,19 +57,18 @@
         "url": "ssh://git@github.com/Epitech/banana-coding-style-checker.git"
       }
     },
-    "vera-fork": {
-      "flake": false,
+    "systems": {
       "locked": {
-        "lastModified": 1661342940,
-        "narHash": "sha256-1nAKhUltQS1301JNrr0PQQrrf2W9Hj5gk1nbUhN4cXw=",
-        "owner": "Epitech",
-        "repo": "banana-vera",
-        "rev": "3a7d18d6249cd1790cc63fb9018e0914462ec219",
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
         "type": "github"
       },
       "original": {
-        "owner": "Epitech",
-        "repo": "banana-vera",
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }
@@ -75,3 +76,4 @@
   "root": "root",
   "version": 7
 }
+

--- a/flake.nix
+++ b/flake.nix
@@ -2,37 +2,16 @@
   description = "Print EPITECH's coding style compliance report";
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    vera-fork.url = "github:Epitech/banana-vera";
-    vera-fork.flake = false;
     ruleset.url = "git+ssh://git@github.com/Epitech/banana-coding-style-checker.git";
     ruleset.flake = false;
     flake-utils.url = "github:numtide/flake-utils";
   };
-  outputs = { self, nixpkgs, vera-fork, ruleset, flake-utils, ... }@inputs:
+  outputs = { self, nixpkgs, ruleset, flake-utils, ... }@inputs:
     flake-utils.lib.eachDefaultSystem
       (system:
         let pkgs = nixpkgs.legacyPackages.${system}; in
         rec {
           packages = flake-utils.lib.flattenTree rec {
-            vera = pkgs.stdenv.mkDerivation {
-              pname = "vera++";
-              version = "1.3.0";
-
-              src = vera-fork;
-
-              nativeBuildInputs = [ pkgs.cmake ];
-              buildInputs = [
-                pkgs.python3
-                (pkgs.boost.override { enablePython = true; python = pkgs.python3; })
-                pkgs.tcl
-              ];
-
-              cmakeFlags = [
-                "-DVERA_LUA=OFF"
-                "-DVERA_USE_SYSTEM_BOOST=ON"
-                "-DPANDOC=OFF"
-              ];
-            };
             report = (pkgs.writeShellScriptBin "cs" ''
               start_time=$(date +%s)
 
@@ -51,15 +30,15 @@
                 -not -path "bonus/*"          \
                 -not -path "tests/*"          \
                 -not -path "/*build/*"        \
-                | ${packages.vera}/bin/vera++ \
+                | ${pkgs.banana-vera}/bin/vera++ \
                 --profile epitech             \
                 --root ${ruleset}/vera        \
                 --error                       \
                 2>&1                          \
                 | sed "s|$project_dir/||"     \
-                | tee /dev/sterr | wc -l
+                | tee /dev/stderr | wc -l
               )
-              
+
               echo "Found $count issues"
               end_time=$(date +%s)
               echo "Ran in $((end_time - start_time))s"
@@ -70,9 +49,6 @@
             '');
             default = report;
           };
-
-          apps.vera.type = "app";
-          apps.vera.program = "${packages.vera}/bin/vera++";
 
           apps.report.type = "app";
           apps.report.program = "${packages.report}/bin/cs";

--- a/flake.nix
+++ b/flake.nix
@@ -57,7 +57,7 @@
                 --error                       \
                 2>&1                          \
                 | sed "s|$project_dir/||"     \
-                | tee /dev/stdout | wc -l
+                | tee /dev/sterr | wc -l
               )
               
               echo "Found $count issues"


### PR DESCRIPTION
- Send report message to the standard error instead of standard output (fix a visibility issue in some special cases)
- Update `flake.lock` file 
  - newer commit of the ruleset
  - use newly introduced `banana-vera` package from `nixos-unstable`
  - smaller flake

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux (do not have the hardware to test)
  - [ ] x86_64-darwin (do not have the hardware to test)
  - [x] aarch64-darwin