### PR TITLE
fix: SELinux labels not dropped

### DIFF
--- a/coding-style.sh
+++ b/coding-style.sh
@@ -57,7 +57,7 @@ then
    
 
     ### generate reports
-    $BASE_EXEC_CMD run --rm -i -v "$DELIVERY_DIR":"/mnt/delivery" -v "$REPORTS_DIR":"/mnt/reports" ghcr.io/epitech/coding-style-checker:latest "/mnt/delivery" "/mnt/reports"
+    $BASE_EXEC_CMD run --rm --security-opt "label:disable" -i -v "$DELIVERY_DIR":"/mnt/delivery" -v "$REPORTS_DIR":"/mnt/reports" ghcr.io/epitech/coding-style-checker:latest "/mnt/delivery" "/mnt/reports"
     [[ -f "$EXPORT_FILE" ]] && echo "$(wc -l < "$EXPORT_FILE") coding style error(s) reported in "$EXPORT_FILE", $(grep -c ": MAJOR:" "$EXPORT_FILE") major, $(grep -c ": MINOR:" "$EXPORT_FILE") minor, $(grep -c ": INFO:" "$EXPORT_FILE") info"
 else
     cat_readme


### PR DESCRIPTION
Immutable distros making use of SELinux labels to avoid the user making breaking changes to core system components would have permission errors when running the coding-style.sh script.

# Errors seen:
![image](https://github.com/Epitech/coding-style-checker/assets/44233177/e5a1e5ee-a64c-4e61-995c-ad1dd35befbd)
This was run while inside the epitest docker container ran by distrobox on Fedora Silverblue 39.
The same error happens when running directly from the host.

The permissions look like this from inside the `fedora:38` docker image with a mounted volume:
![image](https://github.com/Epitech/coding-style-checker/assets/44233177/57a0317d-6031-4cf6-84c7-b7389ac2a134)

# With fix:
![image](https://github.com/Epitech/coding-style-checker/assets/44233177/7e52611f-0876-45b7-8ee6-dbe25f864f0a)

# Related:
https://discussion.fedoraproject.org/t/docker-volume-permission-denied/1948/2