### PR TITLE
[ADD] Create coding style report file when run nix command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Requirement :
 
 Use `coding-style.sh`
 
-If using Nix, you can run `nix run github:epitech/coding-style-checker` to run a script printing you the list of infractions.
+If using Nix, you can run `nix run github:epitech/coding-style-checker`
 
 ### Windows
 
@@ -26,5 +26,5 @@ Requirements :
 
 - [Nix](https://github.com/DeterminateSystems/nix-installer) installed
 
-Use `nix run github:epitech/coding-style-checker` to run a script printing you the list of infractions.
+Use `nix run github:epitech/coding-style-checker`
 (Supports both Intel and Apple Silicon)

--- a/flake.nix
+++ b/flake.nix
@@ -42,8 +42,12 @@
                   project_dir="$1"
               fi
 
-              echo "Running norm in $project_dir"
-              count=$(find "$project_dir"     \
+              export_file=$project_dir/coding-style-reports.log
+
+              rm -f $export_file
+
+              echo "Running norm in $project_dir\n"
+              find "$project_dir"     \
                 -type f                       \
                 -not -path "*/.git/*"         \
                 -not -path "*/.idea/*"        \
@@ -57,10 +61,12 @@
                 --error                       \
                 2>&1                          \
                 | sed "s|$project_dir/||"     \
-                | tee /dev/stdout | wc -l
-              )
-              
-              echo "Found $count issues"
+                | tee > $export_file
+
+              count=$(wc -l < $export_file)
+
+              echo "$count coding style error(s) reported in "$export_file", $(grep -c ": MAJOR:" "$export_file") major, $(grep -c ": MINOR:" "$export_file") minor, $(grep -c ": INFO:" "$export_file") info"
+
               end_time=$(date +%s)
               echo "Ran in $((end_time - start_time))s"
               if [ $count -gt 0 ]; then
@@ -79,4 +85,3 @@
           apps.default = apps.report;
         });
 }
-


### PR DESCRIPTION
When the command "nix run github:epitech/coding-style-checker" was run, the number of coding-style errors doubled.
This modification solves this problem and creates the report file "coding-style-reports.log".